### PR TITLE
Fix package path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```console
-$ yarn add @swan-io/lokalize-sync-cli
+$ yarn add @swan-io/lokalise-sync-cli
 ```
 
 ## Getting started
@@ -13,6 +13,8 @@ First, provide a `LOKALISE_API_KEY` environment variable, containing your Lokali
 Create a `lokalise.config.js` file at the root of your project:
 
 ```js
+require("dotenv").config();
+
 module.exports = [
   {
     name: "your-app-name",


### PR DESCRIPTION
By trying to setup this cli on a project, I discover `paths.src` and `paths.locales` from config wasn't used.  
Also there was some `en.json` harcoded, I replaced them by `${defaulLocale}.json`.  
I added in the example `dotenv` to show a way to load env variables easily.  
And I fixed package name in installation instructions.  